### PR TITLE
Update section headers and enhance app version display in SettingsNavigationView

### DIFF
--- a/saracroche/Views/SettingsNavigationView.swift
+++ b/saracroche/Views/SettingsNavigationView.swift
@@ -6,7 +6,7 @@ struct SettingsNavigationView: View {
   var body: some View {
     NavigationView {
       Form {
-        Section(header: Text("Extension de blocage")) {
+        Section(header: Text("Configuration système")) {
           Button {
             viewModel.openSettings()
           } label: {
@@ -15,9 +15,7 @@ struct SettingsNavigationView: View {
               systemImage: "gearshape.fill"
             )
           }
-        }
-
-        Section(header: Text("Liste de blocage")) {
+          
           Button(role: .destructive) {
             showDeleteConfirmation = true
           } label: {
@@ -112,11 +110,15 @@ struct SettingsNavigationView: View {
               systemImage: "exclamationmark.bubble.fill"
             )
           }
-
+        }
+        
+        HStack {
+          Spacer()
           Text(
-            "Version \(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "")"
+            "Version de l'application : \(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "")"
           )
-          .foregroundColor(.secondary)
+          .font(.footnote)
+          Spacer()
         }
       }
       .navigationTitle("Réglages")


### PR DESCRIPTION
This pull request updates the `SettingsNavigationView` in `saracroche/Views/SettingsNavigationView.swift` to improve the user interface and clarify the displayed information. The most important changes include renaming section headers, removing an unused section, and enhancing the display of the app version.

### User Interface Updates:

* Renamed the section header from "Extension de blocage" to "Configuration système" to better reflect the content of the section.
* Removed the unused "Liste de blocage" section to simplify the settings interface.
* Updated the app version display to include a more descriptive label ("Version de l'application :") and adjusted the formatting by adding a `.font(.footnote)` modifier and centering the text with spacers.