### PR TITLE
Refactor donation section layout in HomeNavigationView

### DIFF
--- a/saracroche/Views/HomeNavigationView.swift
+++ b/saracroche/Views/HomeNavigationView.swift
@@ -290,46 +290,53 @@ struct HomeNavigationView: View {
             )
             .padding(.top)
 
-            VStack(alignment: .leading, spacing: 12) {
-              HStack {
-                Image(systemName: "heart.fill")
-                  .font(.system(size: 20))
-                  .foregroundColor(.red)
-
-                Text("Application gratuite et open-source")
-                  .font(.headline)
-                  .fontWeight(.semibold)
-              }
-
-              Text(
-                "Saracroche est une application entièrement gratuite et open-source. Elle vit grâce aux dons de ses utilisateurs pour continuer à évoluer et rester sans publicité."
-              )
-              .font(.body)
-              .multilineTextAlignment(.leading)
-
-              Button {
-                showDonationSheet = true
-              } label: {
+            if viewModel.blockerPhoneNumberBlocked > 0
+              && viewModel.blocklistVersion
+                == viewModel.blocklistInstalledVersion
+              && viewModel.blockerPhoneNumberBlocked
+                == viewModel.blockerPhoneNumberTotal
+            {
+              VStack(alignment: .leading, spacing: 12) {
                 HStack {
                   Image(systemName: "heart.fill")
-                  Text("Soutenez")
+                    .font(.system(size: 20))
+                    .foregroundColor(.red)
+
+                  Text("Application gratuite et open-source")
+                    .font(.headline)
+                    .fontWeight(.semibold)
                 }
+
+                Text(
+                  "Saracroche est une application entièrement gratuite et open-source. Elle vit grâce aux dons de ses utilisateurs pour continuer à évoluer et rester sans publicité."
+                )
+                .font(.body)
+                .multilineTextAlignment(.leading)
+
+                Button {
+                  showDonationSheet = true
+                } label: {
+                  HStack {
+                    Image(systemName: "heart.fill")
+                    Text("Soutenez")
+                  }
+                }
+                .buttonStyle(
+                  .fullWidth(background: Color.red, foreground: .white)
+                )
               }
-              .buttonStyle(
-                .fullWidth(background: Color.red, foreground: .white)
+              .padding()
+              .frame(maxWidth: .infinity, alignment: .leading)
+              .background(
+                RoundedRectangle(cornerRadius: 16)
+                  .fill(Color.gray.opacity(0.1))
               )
+              .overlay(
+                RoundedRectangle(cornerRadius: 16)
+                  .stroke(Color.gray.opacity(0.3), lineWidth: 1)
+              )
+              .padding(.top)
             }
-            .padding()
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(
-              RoundedRectangle(cornerRadius: 16)
-                .fill(Color.gray.opacity(0.1))
-            )
-            .overlay(
-              RoundedRectangle(cornerRadius: 16)
-                .stroke(Color.gray.opacity(0.3), lineWidth: 1)
-            )
-            .padding(.top)
           }
         }
         .padding()


### PR DESCRIPTION
This pull request introduces a conditional block in the `HomeNavigationView` to display additional content when certain criteria related to the `viewModel` are met. The changes ensure that the UI reacts dynamically based on the state of the `blockerPhoneNumberBlocked` and `blocklistVersion` properties.

### Updates to conditional rendering in `HomeNavigationView`:

* Added a conditional check in `HomeNavigationView` to display a `VStack` only when `viewModel.blockerPhoneNumberBlocked` matches `viewModel.blockerPhoneNumberTotal` and the `blocklistVersion` equals `blocklistInstalledVersion`. This ensures the UI reflects the state of the blocklist accurately.
* Closed the conditional block properly, ensuring the layout and padding are applied consistently.