### PR TITLE
Reduce phone number chunk size from 10,000 to 5,000

### DIFF
--- a/saracroche/Utils/AppConstants.swift
+++ b/saracroche/Utils/AppConstants.swift
@@ -25,6 +25,6 @@ struct AppConstants {
   }
 
   // MARK: - Processing
-  static let phoneNumberChunkSize = 10_000
+  static let phoneNumberChunkSize = 5_000
   static let currentBlocklistVersion = "4"
 }


### PR DESCRIPTION
Adjust the phone number chunk size in AppConstants to improve processing efficiency.