### PR TITLE
Update phone number format instruction in ReportNavigationView

### DIFF
--- a/saracroche/Views/ReportNavigationView.swift
+++ b/saracroche/Views/ReportNavigationView.swift
@@ -24,7 +24,7 @@ struct ReportNavigationView: View {
               .frame(maxWidth: .infinity, alignment: .leading)
 
               Text(
-                "Saisissez le numéro de téléphone au format international E.164"
+                "Saisissez le numéro de téléphone au format international, par exemple +33612345678 pour la France."
               )
               .fontWeight(.semibold)
               .padding(.top, 4)


### PR DESCRIPTION
This pull request makes a minor update to the user guidance text in the `ReportNavigationView` to provide a clearer example of the expected phone number format.

* Updated the phone number instruction text to include a concrete example for France, improving clarity for users entering international numbers. (`saracroche/Views/ReportNavigationView.swift`)