### PR TITLE
Enhance CallDirectoryHandler and BlockerViewModel with improved logging and state management

### DIFF
--- a/blocker/CallDirectoryHandler.swift
+++ b/blocker/CallDirectoryHandler.swift
@@ -17,10 +17,12 @@ class CallDirectoryHandler: CXCallDirectoryProvider {
         handleResetNumbersList(to: context)
       } else if action == "addNumbersList" {
         handleAddNumbersList(to: context)
+      } else {
+        print("Unknown action: \(action)")
       }
-    } else {
-      context.addBlockingEntry(withNextSequentialPhoneNumber: 1_800_555_5555)
-    } 
+    }
+    
+    sharedUserDefaults?.set("", forKey: "action")
 
     context.completeRequest()
   }
@@ -29,11 +31,10 @@ class CallDirectoryHandler: CXCallDirectoryProvider {
     to context: CXCallDirectoryExtensionContext
   ) {
     print("Resetting all numbers list")
+    sharedUserDefaults?.set(0, forKey: "blockedNumbers")
+
     context.removeAllBlockingEntries()
     context.removeAllIdentificationEntries()
-
-    sharedUserDefaults?.set(0, forKey: "blockedNumbers")
-    sharedUserDefaults?.set("", forKey: "action")
   }
 
   private func handleAddNumbersList(to context: CXCallDirectoryExtensionContext)
@@ -54,7 +55,6 @@ class CallDirectoryHandler: CXCallDirectoryProvider {
     }
 
     sharedUserDefaults?.set(blockedNumbers, forKey: "blockedNumbers")
-    sharedUserDefaults?.set("", forKey: "action")
   }
 }
 
@@ -64,12 +64,7 @@ extension CallDirectoryHandler: CXCallDirectoryExtensionContextDelegate {
     for extensionContext: CXCallDirectoryExtensionContext,
     withError error: Error
   ) {
-    // An error occurred while adding blocking or identification entries, check the NSError for details.
-    // For Call Directory error codes, see the CXErrorCodeCallDirectoryManagerError enum in <CallKit/CXError.h>.
-    //
-    // This may be used to store the error details in a location accessible by the extension's containing app, so that the
-    // app may be notified about errors which occurred while loading data even if the request to load data was initiated by
-    // the user in Settings instead of via the app itself.
+    print("Request failed with error: \(error.localizedDescription)")
   }
 
 }

--- a/saracroche/ViewModels/BlockerViewModel.swift
+++ b/saracroche/ViewModels/BlockerViewModel.swift
@@ -16,6 +16,7 @@ class BlockerViewModel: ObservableObject {
   // MARK: - Status Management
   func checkBlockerExtensionStatus() {
     callDirectoryService.checkExtensionStatus { [weak self] status in
+      print("Blocker extension status: \(status)")
       self?.blockerExtensionStatus = status
       self?.updateBlockerState()
     }
@@ -27,6 +28,10 @@ class BlockerViewModel: ObservableObject {
     let totalBlockedNumbers = sharedUserDefaults.getTotalBlockedNumbers()
     let blocklistInstalledVersion = sharedUserDefaults.getBlocklistVersion()
 
+    self.blockerPhoneNumberBlocked = Int64(blockedNumbers)
+    self.blockerPhoneNumberTotal = Int64(totalBlockedNumbers)
+    self.blocklistInstalledVersion = blocklistInstalledVersion
+
     switch blockerActionState {
     case "update":
       self.blockerActionState = .update
@@ -37,15 +42,10 @@ class BlockerViewModel: ObservableObject {
     default:
       self.blockerActionState = .nothing
     }
-
-    self.blockerPhoneNumberBlocked = Int64(blockedNumbers)
-    self.blockerPhoneNumberTotal = Int64(totalBlockedNumbers)
-    self.blocklistInstalledVersion = blocklistInstalledVersion
-
-    switch self.blockerActionState {
-    case .update, .delete, .finish:
+    
+    if self.blockerActionState != .nothing {
       self.showBlockerStatusSheet = true
-    case .nothing:
+    } else {
       self.showBlockerStatusSheet = false
     }
   }
@@ -83,17 +83,17 @@ class BlockerViewModel: ObservableObject {
 
   func cancelUpdateBlockerAction() {
     callDirectoryService.cancelUpdateAction()
-    checkBlockerExtensionStatus()
+    self.checkBlockerExtensionStatus()
   }
 
   func cancelRemoveBlockerAction() {
     callDirectoryService.cancelRemoveAction()
-    checkBlockerExtensionStatus()
+    self.checkBlockerExtensionStatus()
   }
 
   func markBlockerActionFinished() {
     callDirectoryService.markActionFinished()
-    checkBlockerExtensionStatus()
+    self.checkBlockerExtensionStatus()
   }
 
   func openSettings() {


### PR DESCRIPTION
This pull request introduces improvements to error handling, state management, and logging in both the `CallDirectoryHandler` and `BlockerViewModel` classes. The changes enhance clarity in debugging, ensure more reliable state updates, and improve the maintainability of the codebase.

#### Error Handling and Logging Improvements

* Replaced placeholder error comments with explicit logging of errors in the `CallDirectoryHandler` delegate to aid debugging (`blocker/CallDirectoryHandler.swift`).
* Added print statements to log unknown actions and extension status for better traceability in both `CallDirectoryHandler` and `BlockerViewModel` (`blocker/CallDirectoryHandler.swift`, `saracroche/ViewModels/BlockerViewModel.swift`). [[1]](diffhunk://#diff-c90d3d39d9106d8000452325efcebed9266c979e83c658445530cf494c63f6cdL20-L36) [[2]](diffhunk://#diff-97898a8a5153ce544ba1b16cc56b9dae07c1aad548dd8d4ae9ef05c2bf8e70d8R19)

#### State Management and Synchronization

* Ensured that the `action` and `blockedNumbers` keys in `sharedUserDefaults` are reset at appropriate places, preventing stale state between operations in `CallDirectoryHandler` (`blocker/CallDirectoryHandler.swift`). [[1]](diffhunk://#diff-c90d3d39d9106d8000452325efcebed9266c979e83c658445530cf494c63f6cdL20-L36) [[2]](diffhunk://#diff-c90d3d39d9106d8000452325efcebed9266c979e83c658445530cf494c63f6cdL57)
* Updated `BlockerViewModel` to synchronize state variables (`blockerPhoneNumberBlocked`, `blockerPhoneNumberTotal`, `blocklistInstalledVersion`) before switching on `blockerActionState`, ensuring UI reflects the latest data (`saracroche/ViewModels/BlockerViewModel.swift`).

#### UI Logic Refinement

* Refined the logic for displaying the blocker status sheet by checking for `.nothing` state before toggling the UI, making the user experience more predictable (`saracroche/ViewModels/BlockerViewModel.swift`).

#### Code Consistency

* Standardized method calls to use `self.` for clarity and consistency in `BlockerViewModel` action cancellation methods (`saracroche/ViewModels/BlockerViewModel.swift`).