### PR TITLE
Update report server URL reference in NetworkService

### DIFF
--- a/saracroche/Services/NetworkService.swift
+++ b/saracroche/Services/NetworkService.swift
@@ -44,7 +44,7 @@ class NetworkService {
   }
 
   func reportPhoneNumber(_ phoneNumber: String) async throws {
-    guard let url = URL(string: Config.reportServerURL) else {
+    guard let url = URL(string: AppConstants.reportServerURL) else {
       throw NetworkError.invalidURL
     }
 

--- a/saracroche/Utils/AppConstants.swift
+++ b/saracroche/Utils/AppConstants.swift
@@ -8,6 +8,9 @@ struct AppConstants {
   // MARK: - Call Directory Extension
   static let callDirectoryExtensionIdentifier = "com.cbouvat.saracroche.blocker"
 
+  // MARK: - Server URLs
+  static let reportServerURL = "https://saracroche-server.cbouvat.com/report"
+
   // MARK: - Background Tasks
   //static let backgroundUpdateIdentifier = "com.cbouvat.saracroche.background-update"
   //static let backgroundUpdateInterval: TimeInterval = 4 * 60 * 60  // In seconds


### PR DESCRIPTION
This pull request refactors how the report server URL is managed in the codebase to improve maintainability and clarity. The main change is the migration of the server URL constant from the `Config` object to a new location in `AppConstants`.

Configuration refactoring:

* Added the `reportServerURL` constant to the `AppConstants` struct in `AppConstants.swift`, centralizing server URL configuration.
* Updated the `NetworkService` class in `NetworkService.swift` to reference `AppConstants.reportServerURL` instead of `Config.reportServerURL`, ensuring consistency in how configuration values are accessed.